### PR TITLE
3.3.0 -> 3.3.2

### DIFF
--- a/cores/statefulset.yaml
+++ b/cores/statefulset.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: neo4j
-        image: "neo4j:3.3.0-enterprise"
+        image: "neo4j:3.3.2-enterprise"
         imagePullPolicy: "IfNotPresent"
         env:
           - name: NEO4J_dbms_mode

--- a/read-replicas/deployment.yaml
+++ b/read-replicas/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: neo4j
-        image: "neo4j:3.3.0-enterprise"
+        image: "neo4j:3.3.2-enterprise"
         imagePullPolicy: "IfNotPresent"
         env:
           - name: NEO4J_dbms_mode


### PR DESCRIPTION
Just updating to latest images.

Not sure if it's desirable or not to auto-upgrade patch levels, but arguably this could be set to `3.3-enterprise` to catch the latest patch as they come.  `:latest` is probably too far out there.