### PR TITLE
Always use the latest enterprise version

### DIFF
--- a/cores/statefulset.yaml
+++ b/cores/statefulset.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: neo4j
-        image: "neo4j:3.3.2-enterprise"
+        image: "neo4j:enterprise"
         imagePullPolicy: "IfNotPresent"
         env:
           - name: NEO4J_dbms_mode

--- a/read-replicas/deployment.yaml
+++ b/read-replicas/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: neo4j
-        image: "neo4j:3.3.2-enterprise"
+        image: "neo4j:enterprise"
         imagePullPolicy: "IfNotPresent"
         env:
           - name: NEO4J_dbms_mode


### PR DESCRIPTION
This removes the need to specify a version. If this is not a good idea I can also pin it to `3.4-enterprise` or `3.4.5-enterprise`